### PR TITLE
fix: make the shebang work on NixOS

### DIFF
--- a/gh-graph
+++ b/gh-graph
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   cat << EOS >&2


### PR DESCRIPTION
In NixOS `bash` is not located at `/usr/bin/bash`. Changing it to `/usr/bin/env bash` so that it always searches for `bash` in $PATH. THis should work on every unix system.