### PR TITLE
feat: add Nix flake with overlay and home-manager support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766025857,
+        "narHash": "sha256-Lav5jJazCW4mdg1iHcROpuXqmM94BWJvabLFWaJVJp0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "def3da69945bbe338c373fddad5a1bb49cf199ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "GitHub CLI extension to show contribution graph";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{ self, flake-parts, nixpkgs, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        { pkgs, system, ... }:
+        let
+          gh-graph = pkgs.stdenv.mkDerivation {
+            pname = "gh-graph";
+            version = if self ? shortRev then self.shortRev else "dev";
+
+            src = self;
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+
+            installPhase = ''
+              runHook preInstall
+              install -Dm755 gh-graph $out/bin/gh-graph
+              wrapProgram $out/bin/gh-graph \
+                --prefix PATH : ${
+                  pkgs.lib.makeBinPath [
+                    pkgs.curl
+                    pkgs.gh
+                  ]
+                }
+              runHook postInstall
+            '';
+
+            meta = with pkgs.lib; {
+              description = "GitHub CLI extension to show contribution graph";
+              homepage = "https://github.com/kawarimidoll/gh-graph";
+              license = licenses.mit;
+              maintainers = [ ];
+              mainProgram = "gh-graph";
+            };
+          };
+        in
+        {
+          packages = {
+            inherit gh-graph;
+            default = gh-graph;
+          };
+        };
+
+      flake = {
+        overlays.default = _final: prev: {
+          gh-graph = self.packages.${prev.system}.default;
+        };
+
+        homeManagerModules.default =
+          {
+            config,
+            lib,
+            pkgs,
+            ...
+          }:
+          let
+            cfg = config.programs.gh-graph;
+          in
+          {
+            options.programs.gh-graph = {
+              enable = lib.mkEnableOption "gh-graph - GitHub CLI extension to show contribution graph";
+
+              package = lib.mkOption {
+                type = lib.types.package;
+                default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+                description = "The gh-graph package to use.";
+              };
+            };
+
+            config = lib.mkIf cfg.enable {
+              home.packages = [ cfg.package ];
+            };
+          };
+      };
+    };
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` with package, overlay, and home-manager module
- Support for Linux (x86_64, aarch64) and macOS (Intel, Apple Silicon)
- Dependencies (curl, gh) are wrapped in PATH automatically

## Usage

### Direct run
```bash
nix run github:kawarimidoll/gh-graph
```

### As overlay in flake
```nix
{
  inputs.gh-graph.url = "github:kawarimidoll/gh-graph";
  
  # Then use overlays.default
}
```

### With home-manager
```nix
{
  inputs.gh-graph.url = "github:kawarimidoll/gh-graph";
  
  # In your home-manager config:
  imports = [ gh-graph.homeManagerModules.default ];
  programs.gh-graph.enable = true;
}
```

## Test plan

- [x] `nix flake check` passes
- [x] `nix build` succeeds
- [x] Built binary works correctly (`gh-graph --help`)